### PR TITLE
Suspend logging via environment variable

### DIFF
--- a/R/lgr-package.R
+++ b/R/lgr-package.R
@@ -15,8 +15,9 @@
 #'     modifying this option manually use [add_log_levels()] and
 #'     [remove_log_levels()]}
 #'  \item{`lgr.suspend_logging`}{`TRUE` or `FALSE`. Suspend all logging for
-#'    all loggers.  Instead of modifying this option manually use
-#'    [suspend_logging()] and [unsuspend_logging()]}
+#'    all loggers. Defaults to the `TRUE` if the environment variable
+#'    `LGR_SUSPEND_LOGGING` is set to `"TRUE"`. Instead of modifying this 
+#'    option manually use [suspend_logging()] and [unsuspend_logging()]}
 #'  \item{`lgr.user`}{a `character` scalar. The default username for
 #'     `lgr::get_user()`.
 #'   }
@@ -95,6 +96,8 @@ NULL
     "trace" = 600L
   )
 
+  # +- defaults from env vars --------------------------------------------------
+  op.this[["lgr.suspend_logging"]] = identical(Sys.getenv("LGR_SUSPEND_LOGGING"), "TRUE")
 
   # +- set options -------------------------------------------------------------
     toset <- !(names(op.this) %in% names(op))

--- a/man/lgr-package.Rd
+++ b/man/lgr-package.Rd
@@ -22,8 +22,9 @@ known to lgr for labeling, setting thresholds, etc... . Instead of
 modifying this option manually use \code{\link[=add_log_levels]{add_log_levels()}} and
 \code{\link[=remove_log_levels]{remove_log_levels()}}}
 \item{\code{lgr.suspend_logging}}{\code{TRUE} or \code{FALSE}. Suspend all logging for
-all loggers.  Instead of modifying this option manually use
-\code{\link[=suspend_logging]{suspend_logging()}} and \code{\link[=unsuspend_logging]{unsuspend_logging()}}}
+all loggers. Defaults to the \code{TRUE} if the environment variable
+\code{LGR_SUSPEND_LOGGING} is set to \code{"TRUE"}. Instead of modifying this
+option manually use \code{\link[=suspend_logging]{suspend_logging()}} and \code{\link[=unsuspend_logging]{unsuspend_logging()}}}
 \item{\code{lgr.user}}{a \code{character} scalar. The default username for
 \code{lgr::get_user()}.
 }


### PR DESCRIPTION
As a follow up on issue #15, I was looking to find a convenient way to turn off logging while building the documentation via pkgdown. I think that by supporting environment variables, my issues can be solved in a rather convenient way.

This PR allows to set the default for option `lgr.suspend_logging` via the environment variable `LGR_SUSPSEND_LOGGING`. I assume it would also make sense to allow to set the default level (currently hardcoded to 400 in `.onLoad`) via an environment variable. 
