### PR TITLE
Add option to output to stdout or stderr in AppenderConsole

### DIFF
--- a/man/AppenderConsole.Rd
+++ b/man/AppenderConsole.Rd
@@ -67,10 +67,20 @@ Other Appenders:
   threshold = NA_integer_,
   layout = LayoutFormat$new(fmt = "\%L [\%t] \%m \%f", timestamp_fmt = "\%H:\%M:\%OS3",
     colors = getOption("lgr.colors", list())),
-  filters = NULL
+  filters = NULL,
+  output = NULL
 )}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{output}}{Choose whether the message is printed to the \R console as
+regular output (\code{"stdout"}, default in most cases) or as a message
+(\code{"stderr"}, default inside a \pkg{knitr} rendering process).}
+}
+\if{html}{\out{</div>}}
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-AppenderConsole-append"></a>}}

--- a/tests/testthat/test_Appender.R
+++ b/tests/testthat/test_Appender.R
@@ -202,6 +202,41 @@ test_that("AppenderConsole: $filter() works", {
 })
 
 
+test_that("AppenderConsole: $new(output = \"stderr\") works", {
+  app <- AppenderConsole$new(output = "stderr")
+
+  std_out <- textConnection("msg_out", open = "w", local = TRUE)
+  sink(std_out, append = TRUE, type = "message")
+  on.exit(sink(NULL, type = "message"), add = TRUE)
+
+  expect_silent(
+    app$append(event)
+  )
+
+  expect_match(
+    msg_out,
+    "ERROR.*:19:33.*foo.*bar"
+  )
+})
+
+test_that("AppenderConsole: chooses stderr by default when in knitr", {
+  opts <- options(knitr.in.progress = TRUE)
+  on.exit(options(opts), add = TRUE)
+
+  app <- AppenderConsole$new()
+  std_out <- textConnection("msg_out", open = "w", local = TRUE)
+  sink(std_out, append = TRUE, type = "message")
+  on.exit(sink(NULL, type = "message"), add = TRUE)
+
+  expect_silent(
+    app$append(event)
+  )
+
+  expect_match(
+    msg_out,
+    "ERROR.*:19:33.*foo.*bar"
+  )
+})
 
 
 # AppenderBuffer ----------------------------------------------------


### PR DESCRIPTION
The PR is motivated by trying to use `lgr` inside R Markdown documents, where it's generally better to send logging messages to stderr so they aren't captured in the document output.

This PR adds an `output` parameter to `AppenderConsole$new()` that is `NULL` by default but takes either `"stdout"` or `"stderr"`. In the default case, the preference is for `"stdout"` unless running in a knitr rendering process (signaled by the `knitr.in.progress` option being `TRUE`). If a user really wants to output to `stdout` inside knitr, they can use `AppenderConsole$new(output = "stdout")`.