### PR TITLE
Use skip_if_not_installed() to get better skip message

### DIFF
--- a/tests/testthat/test_print_Appender.R
+++ b/tests/testthat/test_print_Appender.R
@@ -4,9 +4,7 @@ context("print_Appender")
 
 
 test_that("all Appenders print() without failure", {
-  if (!requireNamespace("rotor")){
-    skip("Required packages not installed")
-  }
+  skip_if_not_installed("rotor")
 
   tf <- tempfile()
   on.exit(unlink(tf))


### PR DESCRIPTION
Currently, the reason for the skip is not immediately clear, we have to read the source to discover it:

```
• Required packages not installed (1): test_print_Appender.R:8:5
```