### PR TITLE
perf: replace `identical(x, TRUE)` with faster `isTRUE(x)`/`isFALSE(x)`

### DIFF
--- a/R/Filterable.R
+++ b/R/Filterable.R
@@ -28,9 +28,9 @@ Filterable <- R6::R6Class(
           r <- f[["filter"]](event)
         }
 
-        if (identical(r, TRUE)){
+        if (isTRUE(r)){
           # do nothing
-        } else if (identical(r, FALSE)){
+        } else if (isFALSE(r)){
           return(FALSE)
         } else {
           warning(

--- a/R/Logger.R
+++ b/R/Logger.R
@@ -212,8 +212,8 @@ Logger <- R6::R6Class(
 
         # Check if LogEvent should be created
         if (
-          identical(level[[1]] > get("threshold", envir = self), TRUE) ||
-          identical(getOption("lgr.logging_suspended"), TRUE)
+          isTRUE(level[[1]] > get("threshold", envir = self)) ||
+          isTRUE(getOption("lgr.logging_suspended"))
         ){
           return(invisible(msg))
         }
@@ -305,7 +305,7 @@ Logger <- R6::R6Class(
     #' @description Log an Event fatal priority
     #' @param msg,...,caller see `$log()`
     fatal = function(msg, ..., caller = get_caller(-8L)){
-      if (identical(get("threshold", envir = self) < 100L, TRUE))
+      if (isTRUE(get("threshold", envir = self) < 100L))
         return(invisible())
 
       get("log", envir = self)(
@@ -321,7 +321,7 @@ Logger <- R6::R6Class(
     #' @description Log an Event error priority
     #' @param msg,...,caller see `$log()`
     error = function(msg, ..., caller = get_caller(-8L)){
-      if (identical(get("threshold", envir = self) < 200L, TRUE))
+      if (isTRUE(get("threshold", envir = self) < 200L))
         return(invisible())
 
       get("log", envir = self)(
@@ -337,7 +337,7 @@ Logger <- R6::R6Class(
     #' @description Log an Event warn priority
     #' @param msg,...,caller see `$log()`
     warn = function(msg, ..., caller = get_caller(-8L)){
-      if (identical(get("threshold", envir = self) < 300L, TRUE))
+      if (isTRUE(get("threshold", envir = self) < 300L))
         return(invisible())
 
       get("log", envir = self)(
@@ -353,7 +353,7 @@ Logger <- R6::R6Class(
     #' @description Log an Event info priority
     #' @param msg,...,caller see `$log()`
     info = function(msg, ..., caller = get_caller(-8L)){
-      if (identical(get("threshold", envir = self) < 400L, TRUE))
+      if (isTRUE(get("threshold", envir = self) < 400L))
         return(invisible())
 
       get("log", envir = self)(
@@ -369,7 +369,7 @@ Logger <- R6::R6Class(
     #' @description Log an Event debug priority
     #' @param msg,...,caller see `$log()`
     debug = function(msg, ..., caller = get_caller(-8L)){
-      if (identical(get("threshold", envir = self) < 500L, TRUE))
+      if (isTRUE(get("threshold", envir = self) < 500L))
         return(invisible())
 
       get("log", envir = self)(
@@ -385,7 +385,7 @@ Logger <- R6::R6Class(
     #' @description Log an Event trace priority
     #' @param msg,...,caller see `$log()`
     trace = function(msg, ..., caller = get_caller(-8L)){
-      if (identical(get("threshold", envir = self) < 600L, TRUE))
+      if (isTRUE(get("threshold", envir = self) < 600L))
         return(invisible())
 
       get("log", envir = self)(
@@ -781,7 +781,7 @@ LoggerGlue <- R6::R6Class(
   public = list(
 
     fatal = function(..., caller = get_caller(-8L), .envir = parent.frame()){
-      if (identical(get("threshold", envir = self) < 100L, TRUE))
+      if (isTRUE(get("threshold", envir = self) < 100L))
         return(invisible())
 
       force(.envir)
@@ -795,7 +795,7 @@ LoggerGlue <- R6::R6Class(
     },
 
     error = function(..., caller = get_caller(-8L), .envir = parent.frame()){
-      if (identical(get("threshold", envir = self) < 200L, TRUE))
+      if (isTRUE(get("threshold", envir = self) < 200L))
         return(invisible())
 
       get("log", envir = self)(
@@ -808,7 +808,7 @@ LoggerGlue <- R6::R6Class(
     },
 
     warn = function(..., caller = get_caller(-8L), .envir = parent.frame()){
-      if (identical(get("threshold", envir = self) < 300L, TRUE))
+      if (isTRUE(get("threshold", envir = self) < 300L))
         return(invisible())
 
       get("log", envir = self)(
@@ -821,7 +821,7 @@ LoggerGlue <- R6::R6Class(
     },
 
     info = function(..., caller = get_caller(-8L), .envir = parent.frame()){
-      if (identical(get("threshold", envir = self) < 400L, TRUE))
+      if (isTRUE(get("threshold", envir = self) < 400L))
         return(invisible())
 
       get("log", envir = self)(
@@ -834,7 +834,7 @@ LoggerGlue <- R6::R6Class(
     },
 
     debug = function(..., caller = get_caller(-8L), .envir = parent.frame()){
-      if (identical(get("threshold", envir = self) < 500L, TRUE))
+      if (isTRUE(get("threshold", envir = self) < 500L))
         return(invisible())
 
       force(.envir)
@@ -848,7 +848,7 @@ LoggerGlue <- R6::R6Class(
     },
 
     trace = function(..., caller = get_caller(-8L), .envir = parent.frame()){
-      if (identical(get("threshold", envir = self) < 600L, TRUE))
+      if (isTRUE(get("threshold", envir = self) < 600L))
         return(invisible())
 
       force(.envir)
@@ -913,8 +913,8 @@ LoggerGlue <- R6::R6Class(
 
         # Check if LogEvent should be created
         if (
-          identical(level[[1]] > get("threshold", envir = self), TRUE) ||
-          identical(getOption("lgr.logging_suspended"), TRUE)
+          isTRUE(level[[1]] > get("threshold", envir = self)) ||
+          isTRUE(getOption("lgr.logging_suspended"))
         ){
           return(invisible(msg))
         }

--- a/R/utils-sfmisc.R
+++ b/R/utils-sfmisc.R
@@ -112,9 +112,9 @@ assert <- function(
   call. = FALSE,
   domain = NULL
 ){
-  if (identical(cond, TRUE)){
+  if (isTRUE(cond)){
     return(TRUE)
-  } else if (identical(cond, FALSE)){
+  } else if (isFALSE(cond)){
     if (identical(length(list(...)), 0L)){
       msg <- paste0("`", deparse(match.call()[[2]]), "`", " is not 'TRUE'")
       stop(msg, call. = call., domain = domain)
@@ -323,7 +323,7 @@ is_bool <- function(x){
 #' @noRd
 #'
 is_scalar_bool <- function(x){
-  identical(x, TRUE) || identical(x, FALSE)
+  is.logical(x) && length(x) == 1L && !is.na(x)
 }
 
 
@@ -356,14 +356,14 @@ is_scalar_integerish <- function(x){
 
 
 is_n <- function(x){
-  is_scalar_integerish(x) && identical(x > 0, TRUE)
+  is_scalar_integerish(x) && isTRUE(x > 0)
 }
 
 
 
 
 is_n0 <- function(x){
-  is_scalar_integerish(x) && identical(x >= 0, TRUE)
+  is_scalar_integerish(x) && isTRUE(x >= 0)
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -231,7 +231,7 @@ CannotInitializeAbstractClassError <- function(
 
 # stricter & faster thant base R version & support for R < 3.5
 isFALSE <- function(x){
-  identical(x, FALSE)
+  is.logical(x) && length(x) == 1L && !is.na(x) && !x
 }
 
 


### PR DESCRIPTION
Use more concise and performant `isTRUE(x)`/`isFALSE(x)`

``` r
x <- 1:10
bench::mark(identical(x, TRUE), isTRUE(x))
#> # A tibble: 2 × 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 identical(x, TRUE)    533ns    615ns  1221275.        0B        0
#> 2 isTRUE(x)              82ns    123ns  6305751.        0B        0
x <- TRUE
bench::mark(identical(x, TRUE), isTRUE(x))
#> # A tibble: 2 × 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 identical(x, TRUE)    533ns    615ns  1351497.        0B       0 
#> 2 isTRUE(x)             164ns    246ns  3412963.        0B     341.
df <- data.frame(x = rnorm(10), y = rnorm(10))
bench::mark(identical(df, TRUE), isTRUE(df))
#> # A tibble: 2 × 6
#>   expression               min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>          <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 identical(df, TRUE)    533ns    615ns  1526190.        0B        0
#> 2 isTRUE(df)              82ns    123ns  6570761.        0B        0
```

<sup>Created on 2025-04-09 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>