### PR TITLE
fix: remove correct appenders when removing multiple indices

### DIFF
--- a/R/Appender.R
+++ b/R/Appender.R
@@ -897,7 +897,7 @@ AppenderBuffer <- R6::R6Class(
           length(private$.appenders), ")"
         )
 
-        pos <- as.integer(pos)
+        pos <- sort(as.integer(pos), decreasing = TRUE)
       } else if (is.character(pos)) {
         assert(
           all(pos %in% names(private$.appenders)),

--- a/R/Logger.R
+++ b/R/Logger.R
@@ -536,7 +536,7 @@ Logger <- R6::R6Class(
           length(private$.appenders), ")"
         )
 
-        pos <- as.integer(pos)
+        pos <- sort(as.integer(pos), decreasing = TRUE)
       } else if (is.character(pos)) {
         assert(
           all(pos %in% names(private$.appenders)),


### PR DESCRIPTION
This doesn't fix the issue when duplicate indices are provided, but for the other case, it should fix the ordering.