### PR TITLE
Require knitr for related test

### DIFF
--- a/tests/testthat/test_Appender.R
+++ b/tests/testthat/test_Appender.R
@@ -211,6 +211,8 @@ test_that("AppenderConsole - with connection = stderr() - outputs to stderr", {
 
 
 test_that("AppenderConsole: chooses stderr by default when in knitr", {
+  skip_if_not_installed("knitr")
+
   opts <- options(knitr.in.progress = TRUE)
   on.exit(options(opts), add = TRUE)
 


### PR DESCRIPTION
The error on a system lacking {knitr} is very cryptic:

```
── Error (test_Appender.R:213:1): AppenderConsole: chooses stderr by default when in knitr ──
Error in `loadNamespace(x)`: cyclic namespace dependency detected when loading ‘knitr’, already loading ‘knitr’
```
